### PR TITLE
Add setuptools build config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project]
 name = "prospectivity-heatmap"
 version = "0.2.0"


### PR DESCRIPTION
## Summary
- add setuptools build-system configuration to enable editable installs

## Testing
- `ruff check .` *(fails: Import block unsorted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688105786f4c8327b6751a8cfa175596