### PR TITLE
Rename project to prospectivity-tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
-  "name": "prospectivity-heatmap",
+  "name": "prospectivity-tools",
   "build": { "dockerfile": "Dockerfile" },
-  "workspaceFolder": "/workspaces/prospectivity-heatmap",
+  "workspaceFolder": "/workspaces/prospectivity-tools",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prospectivity Heatmap
+# Prospectivity Tools
 
 This repository contains a geospatial prospectivity heatmap generator built using
 H3 hexagonal grids, Folium for visualisation, and a configurable pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "prospectivity-heatmap"
+name = "prospectivity-tools"
 version = "0.2.0"
 description = "Geospatial prospectivity heatmap using H3 indexing"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 ]
 
 [[package]]
-name = "prospectivity-heatmap"
+name = "prospectivity-tools"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- rename project in `pyproject.toml`
- update devcontainer config
- rename project in lock file
- adjust README title

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6881058a2cf88327b736e2cc5933c63b